### PR TITLE
🚀 Add export page command

### DIFF
--- a/media/main.js
+++ b/media/main.js
@@ -159,6 +159,15 @@
     saveState(newState);
   };
 
+  const exportPage = () => {
+    // Update state and get current page's content
+    let newState = getUpdatedContent();
+    saveState(newState);
+    const content = newState.pages[newState.currentPage];
+    // Reply to extension with the text
+    vscode.postMessage({ type: 'exportPage', value: content });
+  };
+
   const previousPage = () => {
     if (currentState.currentPage > 0) {
       let newState = { ...getUpdatedContent(), currentPage: currentState.currentPage - 1 };
@@ -210,6 +219,10 @@
       }
       case 'resetData': {
         saveState(initialState);
+        break;
+      }
+      case 'exportPage': {
+        exportPage();
         break;
       }
     }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,12 @@
 				"category": "Sidebar markdown notes",
 				"title": "Toggle preview",
 				"icon": "$(open-preview)"
+			},
+			{
+				"command": "sidebar-markdown-notes.exportPage",
+				"category": "Sidebar markdown notes",
+				"title": "Export page",
+				"icon": "$(symbol-reference)"
 			}
 		],
 		"menus": {
@@ -93,6 +99,11 @@
 				{
 					"command": "sidebar-markdown-notes.togglePreview",
 					"group": "navigation@2",
+					"when": "view == sidebarMarkdownNotes.webview"
+				},
+				{
+					"command": "sidebar-markdown-notes.exportPage",
+					"group": "navigation@3",
 					"when": "view == sidebarMarkdownNotes.webview"
 				}
 			]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,12 @@ export function activate(context: vscode.ExtensionContext) {
       provider.resetData();
     })
   );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sidebar-markdown-notes.exportPage', () => {
+      provider.exportPage();
+    })
+  );
 }
 
 // this method is called when your extension is deactivated

--- a/src/webviewProvider.ts
+++ b/src/webviewProvider.ts
@@ -47,6 +47,16 @@ export default class SidebarMarkdownNotesProvider implements vscode.WebviewViewP
           this.updateStatusBar(data.value);
           break;
         }
+        case 'exportPage': {
+          vscode.workspace.openTextDocument({ language: 'markdown' }).then((a: vscode.TextDocument) => {
+            vscode.window.showTextDocument(a, 1, false).then((e) => {
+              e.edit((edit) => {
+                edit.insert(new vscode.Position(0, 0), data.value);
+              });
+            });
+          });
+          break;
+        }
       }
     });
 
@@ -79,6 +89,12 @@ export default class SidebarMarkdownNotesProvider implements vscode.WebviewViewP
   public nextPage() {
     if (this._view) {
       this._view.webview.postMessage({ type: 'nextPage' });
+    }
+  }
+
+  public exportPage() {
+    if (this._view) {
+      this._view.webview.postMessage({ type: 'exportPage' });
     }
   }
 


### PR DESCRIPTION
- New command w/ related button added to export the current note
- Opens in an editor as an unsaved Markdown document (.md)

 