### PR TITLE
Removed images directory on .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -15,5 +15,4 @@ node_modules
 .prettierrc.js
 out
 webpack.config.js
-images
 .github


### PR DESCRIPTION
#### Which issue does this Pull Request address?

From [comment](https://github.com/AssisrMatheus/sidebar-markdown-notes/pull/27#issuecomment-1247100594)

#### What does this PR provide?

Fix [Error](https://github.com/AssisrMatheus/sidebar-markdown-notes/actions/runs/3054863344) on Github Actions (build)

Error: 
```
Error: The specified icon 'extension/images/icon.png' wasn't found in the extension.
    at IconProcessor.onEnd (/home/runner/work/_actions/HaaLeo/publish-vscode-extension/v0/dist/index.js:118864:35)
    at /home/runner/work/_actions/HaaLeo/publish-vscode-extension/v0/dist/index.js:119176:58
    at Object.<anonymous> (/home/runner/work/_actions/HaaLeo/publish-vscode-extension/v0/dist/index.js:119816:19)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/_actions/HaaLeo/publish-vscode-extension/v0/dist/index.js:119710:58)
```