### PR TITLE
Unset Markdown Area Background Color, and Align Its Font Size with Editor's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sidebar-markdown-notes
 
-[![Marketplace Version](https://vsmarketplacebadge.apphb.com/version/assisrMatheus.sidebar-markdown-notes.svg 'Current Release')](https://marketplace.visualstudio.com/items?itemName=assisrMatheus.sidebar-markdown-notes)
+[![Marketplace Version](images/icon.png 'Current Release')](https://marketplace.visualstudio.com/items?itemName=assisrMatheus.sidebar-markdown-notes)
 
 Write down notes directly in the sidebar using markdown.
 

--- a/media/vscode.css
+++ b/media/vscode.css
@@ -81,7 +81,7 @@ textarea {
   padding: var(--input-padding-vertical) var(--input-padding-horizontal);
   color: var(--vscode-input-foreground);
   outline-color: var(--vscode-input-border);
-  background-color: var(--vscode-input-background);
+  background-color: unset; /*var(--vscode-input-background);*/
 }
 
 input::placeholder,

--- a/media/vscode.css
+++ b/media/vscode.css
@@ -78,6 +78,7 @@ textarea {
   width: 100%;
   border: none;
   font-family: var(--vscode-font-family);
+  font-size: var(--vscode-editor-font-size);
   padding: var(--input-padding-vertical) var(--input-padding-horizontal);
   color: var(--vscode-input-foreground);
   outline-color: var(--vscode-input-border);


### PR DESCRIPTION
@AssisrMatheus 

I love your extension! So handy having an area in the sidebar dedicated to notes!

Now, I understand the logic behind having the markdown area be a different color than the secondary side bar's. \
However, for me personally I found keeping the area the same color more pleasant on my eyes.

Here is how the extension appears, if you keep the area the same color:

<b>Markdown Area</b>
| before | after |
| - | - |
| <img width="333" alt="Screenshot 2023-05-18 at 4 16 54 PM" src="https://github.com/AssisrMatheus/sidebar-markdown-notes/assets/63764270/9f485fdf-d7a5-40d8-aa3f-160bf51b095e"><br><img width="333" alt="Screenshot 2023-05-18 at 4 16 42 PM" src="https://github.com/AssisrMatheus/sidebar-markdown-notes/assets/63764270/bbf263db-a772-4269-bbd0-27dc3e7d8b5b"><br>&nbsp; | <img width="333" alt="Screenshot 2023-05-18 at 4 13 04 PM" src="https://github.com/AssisrMatheus/sidebar-markdown-notes/assets/63764270/86709600-a07c-41e3-bef3-027ec768c2e3"><br><img width="333" alt="Screenshot 2023-05-18 at 4 12 32 PM" src="https://github.com/AssisrMatheus/sidebar-markdown-notes/assets/63764270/e7b92528-1cdd-4c0d-bb2e-2a61cf893dc6"><br>*markdown area font size 16px aligned with editor's 16px* |

In addition, I changed the SVG in the README to PNG.

When I regenerated the extension (i.e., ran the command, `vsce package`), I encountered an error: "SVGs are restricted in README.md; please use other file image formats, such as PNG: https://vsmarketplacebadge.apphb.com/version/assisrMatheus.sidebar-markdown-notes.svg"

Alright, if you like the idea (match background color and align font sizes), or half of it, feel free to check and merge.

Enjoy!